### PR TITLE
Add JVM unit tests and PR workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -19,7 +19,7 @@ jobs:
     name: Run JVM unit tests
     if: >-
       github.event_name == 'push' ||
-      (github.event_name == 'pull_request_target' &&
+      (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
 
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Check out pull request head
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,44 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: Run JVM unit tests
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: 9.2.1
+
+      - name: Generate Gradle wrapper
+        run: gradle wrapper --no-daemon
+
+      - name: Run unit tests
+        run: ./gradlew testDebug --no-daemon --stacktrace

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -19,12 +19,23 @@ jobs:
     name: Run JVM unit tests
     if: >-
       github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
+        if: github.event_name == 'push'
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check out pull request head
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -41,4 +52,4 @@ jobs:
         run: gradle wrapper --no-daemon
 
       - name: Run unit tests
-        run: ./gradlew testDebug --no-daemon --stacktrace
+        run: ./gradlew :app:testDebugUnitTest --no-daemon --stacktrace

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,7 +175,8 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 
-    // Robolectric dependencies
+    // Unit and Robolectric test dependencies
+    testImplementation(libs.junit)
     testImplementation(libs.androidx.compose.ui.test.junit4)
     testImplementation(libs.robolectric)
 }

--- a/app/src/test/java/com/example/jetnews/data/ResultTest.kt
+++ b/app/src/test/java/com/example/jetnews/data/ResultTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020-2025.
+ * The Android Open Source Project, valo.media GmbH
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetnews.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ResultTest {
+
+    @Test
+    fun successOr_returnsSuccessData() {
+        val result = Result.Success("loaded")
+
+        val actual = result.successOr("fallback")
+
+        assertEquals("loaded", actual)
+    }
+
+    @Test
+    fun successOr_returnsFallbackForError() {
+        val result = Result.Error(IllegalStateException("failed"))
+
+        val actual = result.successOr("fallback")
+
+        assertEquals("fallback", actual)
+    }
+}

--- a/app/src/test/java/com/example/jetnews/data/posts/impl/BlockingFakePostsRepositoryTest.kt
+++ b/app/src/test/java/com/example/jetnews/data/posts/impl/BlockingFakePostsRepositoryTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020-2025.
+ * The Android Open Source Project, valo.media GmbH
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetnews.data.posts.impl
+
+import com.example.jetnews.data.Result
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BlockingFakePostsRepositoryTest {
+
+    @Test
+    fun getPostsFeed_returnsFeedAndUpdatesObservedFeed() = runBlocking {
+        val repository = BlockingFakePostsRepository()
+
+        assertNull(repository.observePostsFeed().first())
+
+        val postsFeed = (repository.getPostsFeed() as Result.Success).data
+
+        assertEquals(postsFeed, repository.observePostsFeed().first())
+    }
+
+    @Test
+    fun toggleFavorite_addsAndRemovesFavoritePost() = runBlocking {
+        val repository = BlockingFakePostsRepository()
+        val postId = (repository.getPostsFeed() as Result.Success).data.highlightedPost.id
+
+        assertEquals(emptySet<String>(), repository.observeFavorites().first())
+
+        repository.toggleFavorite(postId)
+        assertEquals(setOf(postId), repository.observeFavorites().first())
+
+        repository.toggleFavorite(postId)
+        assertEquals(emptySet<String>(), repository.observeFavorites().first())
+    }
+}


### PR DESCRIPTION
closes valomedia/JetNews#5

Adds JVM unit tests for Result.successOr and BlockingFakePostsRepository, adds JUnit as a unit-test dependency, and adds a GitHub Actions Unit Tests workflow for pushes to main and same-repository PRs only. The workflow uses pull_request_target with a same-repository gate before checkout, checks out the PR head SHA only after the gate passes, disables persisted checkout credentials, sets up JDK 17 and Gradle, generates the wrapper, and runs :app:testDebugUnitTest. Committed the final workflow hardening as b53698b (ci: secure unit test workflow). Verification passed: git diff --check; git diff --merge-base main --check; static workflow checks confirmed pull_request_target, no pull_request trigger, same-repo gate, PR head checkout, two persist-credentials: false entries, and the :app:testDebugUnitTest command. Local Gradle/JVM tests could not be executed because java, gradle, and ./gradlew are unavailable in this worker.