### PR TITLE
Add MainActivity instrumented tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         vectorDrawables.useSupportLibrary = true
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "com.example.jetnews.JetnewsTestRunner"
     }
 
     signingConfigs {

--- a/app/src/androidTest/java/com/example/jetnews/JetnewsTestRunner.kt
+++ b/app/src/androidTest/java/com/example/jetnews/JetnewsTestRunner.kt
@@ -18,19 +18,20 @@
 package com.example.jetnews
 
 import android.app.Application
-import com.example.jetnews.data.AppContainer
-import com.example.jetnews.data.AppContainerImpl
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
 
-open class JetnewsApplication : Application() {
-    companion object {
-        const val JETNEWS_APP_URI = "https://developer.android.com/jetnews"
-    }
+class JetnewsTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(
+        cl: ClassLoader,
+        className: String,
+        context: Context
+    ): Application = super.newApplication(cl, TestJetnewsApplication::class.java.name, context)
+}
 
-    // AppContainer instance used by the rest of classes to obtain dependencies
-    lateinit var container: AppContainer
-
+class TestJetnewsApplication : JetnewsApplication() {
     override fun onCreate() {
         super.onCreate()
-        container = AppContainerImpl(this)
+        container = TestAppContainer(this)
     }
 }

--- a/app/src/androidTest/java/com/example/jetnews/MainActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/jetnews/MainActivityInstrumentedTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020-2025.
+ * The Android Open Source Project, valo.media GmbH
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetnews
+
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodes
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.jetnews.ui.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityInstrumentedTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun mainActivity_launchesHomeFeed() {
+        composeTestRule.onNodeWithText("Top stories for you").assertExists()
+    }
+
+    @Test
+    fun mainActivity_showsNavigationDestinations() {
+        val drawerButtons = composeTestRule
+            .onAllNodes(hasContentDescription("Open navigation drawer"), useUnmergedTree = true)
+            .fetchSemanticsNodes()
+
+        if (drawerButtons.isNotEmpty()) {
+            composeTestRule.onNodeWithContentDescription(
+                label = "Open navigation drawer",
+                useUnmergedTree = true
+            ).performClick()
+
+            composeTestRule.onNodeWithText("Home").assertExists()
+            composeTestRule.onNodeWithText("Interests").assertExists()
+        } else {
+            composeTestRule.onNodeWithContentDescription("Home").assertExists()
+            composeTestRule.onNodeWithContentDescription("Interests").assertExists()
+        }
+    }
+}


### PR DESCRIPTION
closes valomedia/JetNews#11

Configured Android instrumented testing to use a custom JetnewsTestRunner and TestJetnewsApplication that injects the shared TestAppContainer, keeping device tests on fake repositories instead of the HTTP-backed app container. Added MainActivityInstrumentedTest coverage for launching the home feed and exposing navigation destinations in both compact drawer and expanded navigation-rail layouts. Made JetnewsApplication open so the androidTest application can subclass it. Verification: git diff --check passed; attempted Gradle androidTest compilation, but this environment has no checked-in ./gradlew and no gradle executable on PATH, so Gradle verification could not be run here. Committed as f88f883 test: add MainActivity instrumented tests.