### PR TITLE
Add Android instrumented test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,45 @@ jobs:
 
       - name: Run JVM unit and Robolectric tests
         run: ./gradlew :app:testDebugUnitTest --no-daemon --stacktrace
+
+  instrumented-tests:
+    name: Instrumented tests
+    # Fork PRs are skipped intentionally by repository policy.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: 9.2.1
+
+      - name: Generate Gradle wrapper
+        run: gradle wrapper --no-daemon
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          arch: x86_64
+          script: ./gradlew connectedCheck --no-daemon --stacktrace

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         vectorDrawables.useSupportLibrary = true
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "com.example.jetnews.JetnewsTestRunner"
     }
 
     signingConfigs {

--- a/app/src/androidTest/java/com/example/jetnews/JetnewsTestRunner.kt
+++ b/app/src/androidTest/java/com/example/jetnews/JetnewsTestRunner.kt
@@ -18,19 +18,20 @@
 package com.example.jetnews
 
 import android.app.Application
-import com.example.jetnews.data.AppContainer
-import com.example.jetnews.data.AppContainerImpl
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
 
-open class JetnewsApplication : Application() {
-    companion object {
-        const val JETNEWS_APP_URI = "https://developer.android.com/jetnews"
-    }
+class JetnewsTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(
+        cl: ClassLoader,
+        className: String,
+        context: Context
+    ): Application = super.newApplication(cl, TestJetnewsApplication::class.java.name, context)
+}
 
-    // AppContainer instance used by the rest of classes to obtain dependencies
-    lateinit var container: AppContainer
-
+class TestJetnewsApplication : JetnewsApplication() {
     override fun onCreate() {
         super.onCreate()
-        container = AppContainerImpl(this)
+        container = TestAppContainer(this)
     }
 }

--- a/app/src/androidTest/java/com/example/jetnews/JetnewsTestRunner.kt
+++ b/app/src/androidTest/java/com/example/jetnews/JetnewsTestRunner.kt
@@ -20,6 +20,7 @@ package com.example.jetnews
 import android.app.Application
 import android.content.Context
 import androidx.test.runner.AndroidJUnitRunner
+import com.example.jetnews.data.AppContainer
 
 class JetnewsTestRunner : AndroidJUnitRunner() {
     override fun newApplication(
@@ -30,8 +31,5 @@ class JetnewsTestRunner : AndroidJUnitRunner() {
 }
 
 class TestJetnewsApplication : JetnewsApplication() {
-    override fun onCreate() {
-        super.onCreate()
-        container = TestAppContainer(this)
-    }
+    override fun createAppContainer(): AppContainer = TestAppContainer(this)
 }

--- a/app/src/androidTest/java/com/example/jetnews/MainActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/jetnews/MainActivityInstrumentedTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020-2025.
+ * The Android Open Source Project, valo.media GmbH
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetnews
+
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodes
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.jetnews.ui.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityInstrumentedTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun mainActivity_launchesHomeFeed() {
+        composeTestRule.onNodeWithText("Top stories for you").assertExists()
+    }
+
+    @Test
+    fun mainActivity_showsNavigationDestinations() {
+        val drawerButtons = composeTestRule
+            .onAllNodes(hasContentDescription("Open navigation drawer"), useUnmergedTree = true)
+            .fetchSemanticsNodes()
+
+        if (drawerButtons.isNotEmpty()) {
+            composeTestRule.onNodeWithContentDescription(
+                label = "Open navigation drawer",
+                useUnmergedTree = true
+            ).performClick()
+
+            composeTestRule.onNodeWithText("Home").assertExists()
+            composeTestRule.onNodeWithText("Interests").assertExists()
+        } else {
+            composeTestRule.onNodeWithContentDescription("Home").assertExists()
+            composeTestRule.onNodeWithContentDescription("Interests").assertExists()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/example/jetnews/MainActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/jetnews/MainActivityInstrumentedTest.kt
@@ -19,7 +19,6 @@ package com.example.jetnews
 
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/main/java/com/example/jetnews/JetnewsApplication.kt
+++ b/app/src/main/java/com/example/jetnews/JetnewsApplication.kt
@@ -31,6 +31,8 @@ open class JetnewsApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        container = AppContainerImpl(this)
+        container = createAppContainer()
     }
+
+    protected open fun createAppContainer(): AppContainer = AppContainerImpl(this)
 }


### PR DESCRIPTION
closes valomedia/JetNews#11

Added end-to-end Android instrumented coverage for MainActivity, including home-feed launch assertions and navigation destination checks that handle both compact drawer and expanded navigation-rail layouts. Configured the app to use JetnewsTestRunner for instrumentation, backed by TestJetnewsApplication and TestAppContainer, and refactored JetnewsApplication to expose a small app-container factory hook for clean test substitution. Added a CI instrumented-tests job that sets up Java and Gradle, generates the Gradle wrapper, enables KVM, boots an Android emulator with reactivecircus/android-emulator-runner, and runs connectedCheck. Committed the final changes with `test: wire instrumented tests into CI`. Verification: `git diff --check` passed, `.github/workflows/ci.yml` parsed successfully with Python YAML, and static project checks confirmed the runner, factory hook, instrumented tests, and CI emulator job are wired as expected. Gradle/Android execution could not be run in this worker because Java and Gradle are unavailable and the checkout has no `./gradlew`.