### PR TITLE
chore: configure Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>valomedia/renovate-config"]
+}


### PR DESCRIPTION
closes valomedia/JetNews#3

Added a root-level renovate.json that extends the shared github>valomedia/renovate-config preset. No local automerge override was added because the shared preset already gates automerge on required status checks and this repository has a CI workflow with recent successful runs. Verified Renovate-relevant files are present for Gradle and GitHub Actions: build.gradle.kts, app/build.gradle.kts, settings.gradle.kts, gradle/libs.versions.toml, and .github/workflows/ci.yml. Checked for existing open Renovate Dependency Dashboard/update PRs before merge and found none. Verification: python3 -m json.tool renovate.json passed, git diff --check passed, a Python assertion check confirmed the expected Renovate config values and manager files, and gh run list confirmed recent CI runs including a successful main run.