### PR TITLE
Add dedicated CI build validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,38 @@ permissions:
   contents: read
 
 jobs:
+  build:
+    name: Build validation
+    # Fork PRs are skipped intentionally by repository policy.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: 9.2.1
+
+      - name: Generate Gradle wrapper
+        run: gradle wrapper --no-daemon
+
+      - name: Run build validation
+        run: ./gradlew :app:assembleDebug --no-daemon --stacktrace
+
   unit-tests:
     name: JVM unit and Robolectric tests
     # Fork PRs are skipped intentionally by repository policy.


### PR DESCRIPTION
closes valomedia/JetNews#15

Added a dedicated CI build job/check that uses the same checkout, JDK 17, Gradle 9.2.1 setup, and Gradle wrapper generation pattern as the existing CI jobs. The build job runs `./gradlew :app:assembleDebug --no-daemon --stacktrace`, keeping JVM/Robolectric tests in `unit-tests` and instrumented tests in `instrumented-tests`, while preserving the existing push/pull_request triggers and fork-PR skip policy. Verification: ran `git diff --check`; parsed `.github/workflows/ci.yml` with Python YAML and `yq`; asserted separate `build`, `unit-tests`, and `instrumented-tests` jobs, matching setup/fork policy, and expected Gradle commands. Local Gradle execution was not run because this environment has neither `gradle` nor a checked-in `gradlew`. Committed as `670ee0e ci: add dedicated build validation job`.