### PR TITLE
Remove manual fork PR workflow skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ permissions:
 jobs:
   build:
     name: Build validation
-    # Fork PRs are skipped intentionally by repository policy.
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
 
     steps:
@@ -49,11 +44,6 @@ jobs:
 
   unit-tests:
     name: JVM unit and Robolectric tests
-    # Fork PRs are skipped intentionally by repository policy.
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
 
     steps:
@@ -81,11 +71,6 @@ jobs:
 
   instrumented-tests:
     name: Instrumented tests
-    # Fork PRs are skipped intentionally by repository policy.
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
closes valomedia/JetNews#21

Removed the repository-local fork/cross-repo pull request skip comments and job-level `if` conditions from the CI workflow's `build`, `unit-tests`, and `instrumented-tests` jobs. The ordinary `push` and `pull_request` triggers remain intact, so org-level approval policy now controls dangerous cross-repo PR workflow execution. Verification: parsed `.github/workflows/ci.yml` with PyYAML, confirmed the three expected jobs remain, confirmed the `pull_request` trigger is retained, confirmed no job-level `if` conditions, `head.repo.full_name` checks, or fork-skip comments remain, and ran `git diff --check`. Local Gradle gates were not run because this checkout has no `gradlew` and `gradle` is not installed in the worker environment. Committed as `502a681 ci: remove manual fork PR skip conditions`.