### PR TITLE
ci: add Android lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,33 @@ jobs:
       - name: Run JVM unit and Robolectric tests
         run: ./gradlew :app:testDebugUnitTest --no-daemon --stacktrace
 
+  lint:
+    name: Android lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: 9.2.1
+
+      - name: Generate Gradle wrapper
+        run: gradle wrapper --no-daemon
+
+      - name: Run Android lint
+        run: ./gradlew :app:lintDebug --no-daemon --stacktrace
+
   instrumented-tests:
     name: Instrumented tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ gradle wrapper
 With `gradlew` installed, you can build the project by running:
 
 ```shell
-gradlew build
+./gradlew build
+```
+
+Run Android lint locally with:
+
+```shell
+./gradlew :app:lintDebug --no-daemon --stacktrace
 ```
 
 The gradle wrapper and the gradle version it uses will automatically be updated to the correct


### PR DESCRIPTION
closes valomedia/JetNews#16

Branch changes: added a dedicated `lint` job to `.github/workflows/ci.yml` using the existing checkout, JDK 17, Gradle 9.2.1 setup, wrapper-generation pattern, and `./gradlew :app:lintDebug --no-daemon --stacktrace`. Documented the repository-local lint command in `README.md` and updated the build example to use `./gradlew`.

Verification: `git diff --check --merge-base main` passed; `.github/workflows/ci.yml` parsed successfully and the lint job shape was checked; `gh api` inspection of `valomedia/github-workflows` found no shared Android CI workflow to reuse; `./gradlew :app:tasks --all --no-daemon --stacktrace` succeeded and listed `lint` and `lintDebug`. I also re-ran `./gradlew :app:lintDebug --no-daemon --stacktrace`; it still cannot execute in this worker because `ANDROID_HOME`/`ANDROID_SDK_ROOT` are unset and no Android SDK is configured. Per the maintainer comment, final lint execution should be verified by GitHub-hosted CI. Working tree is clean, so no empty commit was created.